### PR TITLE
Configure microbundle to generate type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "./dist/rawproto.cjs",
   "module": "./dist/rawproto.module.js",
   "unpkg": "./dist/rawproto.umd.js",
+  "types": "./dist/rawproto.d.ts",
   "scripts": {
     "test": "vitest --run --globals",
     "build": "microbundle",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "include": [
+        "./*.js"
+    ],
+    "compilerOptions": {
+        "allowJs": true,
+        "noEmit": true,
+        "declaration": true
+    }
+}


### PR DESCRIPTION
See https://www.npmjs.com/package/microbundle#using-with-typescript for more info.

It turns out, if you just specify as `types` field in your package.json, microbundle will automatically generate type definitions into the given path, and use any jsdoc to do so (and just set any unknown types as `any` - i.e. explicitly unchecked types - which is a reasonable fallback imo).

The `tsconfig.json` is required because by default microbundle only generates types for the single file, but because the entrypoint re-exports values from other files, the types for those files need to be generated too.

With this change and the new jsdoc, downstream TypeScript code now compiles without any extra configuration.